### PR TITLE
Fix missing bbls

### DIFF
--- a/arxiv_collector.py
+++ b/arxiv_collector.py
@@ -306,7 +306,6 @@ def collect(
     if len(bbl_pths) == 0 and used_bib:
         error("Used a .bib file, but didn't find any .bbl file")
     for bbl_pth in bbl_pths:
-        print(f"archiving {bbl_pth} with arcname {base_name + '.bbl'}")
         add(bbl_pth)
 
     if extract_bib_name:

--- a/arxiv_collector.py
+++ b/arxiv_collector.py
@@ -301,12 +301,13 @@ def collect(
         else:
             expect(bogus, ["[end of file]"], deps_file)
 
-    bbl_pth = jobname + ".bbl"
-    if os.path.exists(bbl_pth):
-        add(bbl_pth, arcname=base_name + ".bbl")
-    elif used_bib:
-        msg = "Used a .bib file, but didn't find '{}'; this likely won't work."
-        error(msg.format(bbl_pth))
+    from glob import glob
+    bbl_pths = glob(f"{jobname}*.bbl")
+    if len(bbl_pths) == 0 and used_bib:
+        error("Used a .bib file, but didn't find any .bbl file")
+    for bbl_pth in bbl_pths:
+        print(f"archiving {bbl_pth} with arcname {base_name + '.bbl'}")
+        add(bbl_pth)
 
     if extract_bib_name:
         info("Running biber on {}.bcf...".format(base_name))


### PR DESCRIPTION
For tex files that use `biblatex` with the `bibtex` backend and `refsection`s, there is a specific `.bbl` file created for each `refsection`, see the following MWE:
```latex
\documentclass{article}
\usepackage[
    backend=bibtex,
]{biblatex}
\addbibresource{\jobname.bib}

\begin{filecontents}{\jobname.bib}
@book{key1,
  author = {Author, A.},
  year = {2001},
  title = {Title},
  publisher = {Publisher},
}
@book{key2,
  author = {Author, B.},
  year = {2002},
  title = {Title2},
  publisher = {Publisher2},
}
\end{filecontents}

\begin{document}

\cite{key1}

\printbibliography

\section*{Supplementary Information}
\begin{refsection}
    \cite{key2}
\printbibliography[heading=subbibliography]
\end{refsection}
\end{document}
```
Calling this `main.tex`, compiling produces multiple `.bbl` files, but `arxiv-collector` only uses `main.bbl`:
```
$ latexmk -pdf main.tex >/dev/null 2>&1
$ ls *.bbl
main1-blx.bbl  main.bbl
$ arxiv-collector main.tex
Building main...
Gathering outputs...
Output in arxiv.tar.gz: 14 files, 143KiB compressed
$ tar -tf arxiv.tar.gz | grep .bbl
main.bbl
```


This pull requests introduces globbing to find all `bbl` files, so `tar -tf arxiv.tar.gz` lists both `main.bbl` and `main1-blx.bbl`.
```
$ arxiv-collector main.tex
Building main...
Gathering outputs...
Output in arxiv.tar.gz: 15 files, 143KiB compressed
$ tar -tf arxiv.tar.gz | grep .bbl
main1-blx.bbl main.bbl
```

I'm not sure this scenario is one that you want to support, but I had this problem a few times and when looking into the code the solution was clear.